### PR TITLE
feat: Add CLI alternatives and collapse Windows sections in wiki

### DIFF
--- a/wiki/02-Install-VS-Code.md
+++ b/wiki/02-Install-VS-Code.md
@@ -6,7 +6,10 @@ VS Code (Visual Studio Code) is a **code editor**  - the program you'll write co
 
 ## Install VS Code
 
-**Windows:**
+<details>
+<summary>Windows</summary>
+
+**GUI method:**
 1. Go to [code.visualstudio.com](https://code.visualstudio.com/)
 2. Click the big blue **Download for Windows** button
 3. Run the installer. Accept the defaults, but **check these boxes** if they appear:
@@ -15,9 +18,18 @@ VS Code (Visual Studio Code) is a **code editor**  - the program you'll write co
    - "Add 'Open with Code' action to directory context menu" ✅
 4. Finish the install and open VS Code
 
+**CLI method:**
+```powershell
+winget install Microsoft.VisualStudioCode
+```
+> **What's `winget`?** It's Windows' built-in package manager — a way to install programs from the command line instead of downloading installers from websites.
+
+</details>
+
 <details>
 <summary>Mac</summary>
 
+**GUI method:**
 1. Go to [code.visualstudio.com](https://code.visualstudio.com/)
 2. Click **Download for Mac**
 3. Open the downloaded `.zip` file
@@ -25,12 +37,18 @@ VS Code (Visual Studio Code) is a **code editor**  - the program you'll write co
 5. Open it from Applications
 6. To use `code` from the terminal: open the Command Palette (`Cmd+Shift+P`), type "shell command", and select **"Install 'code' command in PATH"**
 
+**CLI method:**
+```bash
+brew install --cask visual-studio-code
+```
+> This requires [Homebrew](https://brew.sh/). If you don't have it, use the GUI method above.
+
 </details>
 
 <details>
 <summary>Linux</summary>
 
-The easiest path is using Snap:
+**CLI method (Snap):**
 ```bash
 sudo snap install code --classic
 ```
@@ -80,6 +98,12 @@ Search for and install these:
 |-----------|-------------|
 | **GitLens** | Shows who changed each line of code and when. Makes Git visual. |
 | **Prettier** | Automatically formats your code so it looks neat and consistent. |
+
+**CLI method:** You can also install extensions from the terminal:
+```bash
+code --install-extension eamodio.gitlens
+code --install-extension esbenp.prettier-vscode
+```
 
 > **Note:** You may install additional extensions later depending on your project (like the Python extension for Python projects). Claude Code will recommend them when the time comes.
 

--- a/wiki/03-Install-Git.md
+++ b/wiki/03-Install-Git.md
@@ -10,7 +10,10 @@ Imagine you're writing an essay and you save a new copy every time you make a bi
 
 ## Install Git
 
-**Windows:**
+<details>
+<summary>Windows</summary>
+
+**GUI method:**
 1. Go to [git-scm.com](https://git-scm.com/)
 2. Click **Download for Windows**
 3. Run the installer. The defaults are fine for most settings, but pay attention to these:
@@ -18,6 +21,13 @@ Imagine you're writing an essay and you save a new copy every time you make a bi
    - **PATH environment:** Choose "Git from the command line and also from 3rd-party software" (usually the default)
    - **Line ending conversions:** Choose "Checkout Windows-style, commit Unix-style line endings" (the default)
 4. Finish the install
+
+**CLI method:**
+```powershell
+winget install Git.Git
+```
+
+</details>
 
 <details>
 <summary>Mac</summary>
@@ -141,6 +151,12 @@ When it asks:
 3. Give it a name (like "My Laptop")
 4. Paste your public key into the "Key" field
 5. Click **Add SSH key**
+
+**CLI method:** If you have the GitHub CLI (`gh`) installed and authenticated, you can do this in one command:
+```bash
+gh ssh-key add ~/.ssh/id_ed25519.pub --title "My Laptop"
+```
+> Don't have `gh` yet? Install it: `winget install GitHub.cli` (Windows), `brew install gh` (Mac), or `sudo apt install gh` (Linux). Then run `gh auth login` to authenticate.
 
 ### Verify it works:
 

--- a/wiki/05-Install-Node.md
+++ b/wiki/05-Install-Node.md
@@ -17,22 +17,23 @@ We're going to install Node.js using something called **fnm** (Fast Node Manager
 
 ## Install fnm
 
-**Windows:**
+<details>
+<summary>Windows</summary>
 
 1. Open PowerShell and run:
    ```powershell
    winget install Schniz.fnm
    ```
-   > **What's `winget`?** It's Windows' built-in package manager - a way to install programs from the command line instead of downloading installers from websites. It comes pre-installed on Windows 10 (version 1809+) and Windows 11.
+   > **What's `winget`?** It's Windows' built-in package manager — a way to install programs from the command line instead of downloading installers from websites. It comes pre-installed on Windows 10 (version 1809+) and Windows 11.
 
 2. **Set up your shell profile.** This step tells PowerShell to activate fnm every time you open a terminal. Run this command:
    ```powershell
    if (!(Test-Path $PROFILE)) { New-Item -Path $PROFILE -Force }
    Add-Content -Path $PROFILE -Value 'fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression'
    ```
-   > **What's a shell profile?** It's a script that runs automatically every time you open a new terminal window. Think of it like startup settings for your command line. The file lives at `$PROFILE` - you can type that in PowerShell to see the exact path.
+   > **What's a shell profile?** It's a script that runs automatically every time you open a new terminal window. Think of it like startup settings for your command line. The file lives at `$PROFILE` — you can type that in PowerShell to see the exact path.
 
-3. **Close and reopen your terminal** (or restart VS Code) - this is important so the new commands are recognized.
+3. **Close and reopen your terminal** (or restart VS Code) — this is important so the new commands are recognized.
 
 4. Verify fnm installed:
    ```powershell
@@ -42,6 +43,8 @@ We're going to install Node.js using something called **fnm** (Fast Node Manager
    ```
    fnm 1.39.0
    ```
+
+</details>
 
 <details>
 <summary>Mac / Linux</summary>

--- a/wiki/07-Clone-This-Repo.md
+++ b/wiki/07-Clone-This-Repo.md
@@ -6,6 +6,7 @@ Now we'll get the First Build project onto your computer. This is a two-step pro
 
 ## Step 1: Create Your Copy from the Template
 
+**GUI method:**
 1. Go to the **[First Build repository on GitHub](https://github.com/cherry-pit-labs/first-build)**
 2. Click the green **"Use this template"** button near the top-right of the page
 3. Select **"Create a new repository"**
@@ -15,6 +16,11 @@ Now we'll get the First Build project onto your computer. This is a two-step pro
    - **Description:** Optional - add one if you want
    - **Visibility:** Choose **Private** for now (you can make it public later as a portfolio piece)
 5. Click **"Create repository"**
+
+**CLI method:** If you have the GitHub CLI (`gh`) installed:
+```bash
+gh repo create first-build --template cherry-pit-labs/first-build --private
+```
 
 You now have your own copy of this project on your GitHub account. This is *your* repo - you can do whatever you want with it without affecting the original.
 
@@ -26,10 +32,14 @@ Open VS Code and open the terminal (`` Ctrl+` ``).
 
 Navigate to where you want to keep your projects. A common choice:
 
-**Windows:**
+<details>
+<summary>Windows</summary>
+
 ```bash
 cd ~/Documents
 ```
+
+</details>
 
 <details>
 <summary>Mac / Linux</summary>


### PR DESCRIPTION
## Summary
- Added CLI install methods (`winget`, `brew`, `apt`, `snap`) for VS Code, Git, and GitHub CLI alongside existing GUI instructions
- Added CLI methods for VS Code extension install, SSH key upload to GitHub, and repo creation from template
- Collapsed Windows instructions into `<details>` blocks to match Mac/Linux formatting, keeping Windows listed first

Closes #1, closes #2

## Test plan
- [ ] Verify all `<details>` blocks render correctly on the wiki
- [ ] Confirm Windows appears first and collapsed on each page
- [ ] Spot-check CLI commands are accurate (`winget install`, `brew install`, `code --install-extension`, `gh ssh-key add`, `gh repo create --template`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)