### PR TITLE
feat: Add GitHub Action to sync wiki to GitHub wiki

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,22 @@
+name: Sync Wiki
+
+on:
+  push:
+    branches: [main]
+    paths: [wiki/**]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Sync wiki directory to GitHub wiki
+        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: wiki/
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that automatically syncs the `wiki/` directory to the GitHub wiki
- Triggers only on pushes to `main` that change files in `wiki/`
- Uses [github-wiki-action](https://github.com/Andrew-Chen-Wang/github-wiki-action) v4

## Notes
- The wiki must have at least one page created manually before this action can push to it (GitHub doesn't create the wiki repo until the first page exists)
- Uses `GITHUB_TOKEN` — no additional secrets needed

## Test plan
- [ ] Merge this PR
- [ ] Make a small change to a file in `wiki/` on main
- [ ] Verify the GitHub wiki updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)