### PR TITLE
feat: Add manual trigger to wiki sync action

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths: [wiki/**]
+  workflow_dispatch:
 
 jobs:
   sync:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the wiki sync action so it can be run manually from the Actions tab or via `gh workflow run "Sync Wiki"`

## Test plan
- [ ] Merge, then trigger manually from **Actions > Sync Wiki > Run workflow**
- [ ] Verify the wiki updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)