### PR TITLE
fix: Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Sync wiki directory to GitHub wiki
-        uses: Andrew-Chen-Wang/github-wiki-action@v4
+        uses: Andrew-Chen-Wang/github-wiki-action@v5
         with:
           path: wiki/
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Updated `actions/checkout` from v4 to v6
- Updated `github-wiki-action` from v4 to v5
- Resolves the Node.js 20 deprecation warning

## Test plan
- [ ] Merge and trigger the wiki sync workflow
- [ ] Verify no Node.js deprecation warnings in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)