### PR TITLE
fix: Add SSH troubleshooting note to Clone This Repo page

### DIFF
--- a/wiki/07-Clone-This-Repo.md
+++ b/wiki/07-Clone-This-Repo.md
@@ -65,6 +65,8 @@ git clone git@github.com:YOUR_USERNAME/first-build.git
 - `git clone` - "Download a repository"
 - `git@github.com:YOUR_USERNAME/first-build.git` - The SSH address of your repo (this is why we set up SSH keys earlier)
 
+> **Getting "Permission denied (publickey)"?** This means your SSH key isn't set up yet (or isn't linked to your GitHub account). Go back to [Install Git — Generate an SSH Key](03-Install-Git#generate-an-ssh-key), complete that section, then come back here and try the clone again.
+
 You should see output like:
 ```
 Cloning into 'first-build'...


### PR DESCRIPTION
## Summary
- Added a blockquote tip after the `git clone` command for "Permission denied (publickey)" errors
- Directs the learner back to step 3's SSH key setup section, then to return and retry

Closes #13

## Test plan
- [ ] Verify the anchor link to `03-Install-Git#generate-an-ssh-key` works in the wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)