### PR TITLE
fix: Remove GitHub CLI references from wiki pages

### DIFF
--- a/wiki/03-Install-Git.md
+++ b/wiki/03-Install-Git.md
@@ -152,12 +152,6 @@ When it asks:
 4. Paste your public key into the "Key" field
 5. Click **Add SSH key**
 
-**CLI method:** If you have the GitHub CLI (`gh`) installed and authenticated, you can do this in one command:
-```bash
-gh ssh-key add ~/.ssh/id_ed25519.pub --title "My Laptop"
-```
-> Don't have `gh` yet? Install it: `winget install GitHub.cli` (Windows), `brew install gh` (Mac), or `sudo apt install gh` (Linux). Then run `gh auth login` to authenticate.
-
 ### Verify it works:
 
 ```bash

--- a/wiki/07-Clone-This-Repo.md
+++ b/wiki/07-Clone-This-Repo.md
@@ -18,11 +18,6 @@ Now we'll get the First Build project onto your computer. This is a two-step pro
    - **Visibility:** Choose **Private** for now (you can make it public later as a portfolio piece)
 5. Click **"Create repository"**
 
-**CLI method:** If you have the GitHub CLI (`gh`) installed:
-```bash
-gh repo create first-build --template cherry-pit-labs/first-build --private
-```
-
 You now have your own copy of this project on your GitHub account. This is *your* repo - you can do whatever you want with it without affecting the original.
 
 **What's a template?** A template repository is a starting point. When you create a repo from a template, GitHub copies all the files into a brand-new repository on your account. It's like getting a fresh copy of a workbook - same starting content, but your version is completely independent.


### PR DESCRIPTION
## Summary
- Removed `gh ssh-key add` CLI method and `gh` install instructions from 03-Install-Git.md
- Removed `gh repo create --template` CLI method from 07-Clone-This-Repo.md
- The guide uses SSH for authentication — `gh` is never installed as part of setup, so these references would confuse beginners

Closes #15

## Test plan
- [ ] Grep wiki for remaining `gh ` references — should only match incidental words (e.g., "through")
- [ ] Read steps 3 and 7 to confirm flow still makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)