### PR TITLE
fix: Wrap 'What's happening here' in collapsible details blocks

### DIFF
--- a/wiki/02-Install-VS-Code.md
+++ b/wiki/02-Install-VS-Code.md
@@ -23,10 +23,14 @@ VS Code (Visual Studio Code) is a **code editor**, the program you'll write code
 winget install Microsoft.VisualStudioCode
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `winget` is Windows' built-in package manager, a way to install programs from the command line instead of downloading installers from websites
 - `install` tells winget to install a program
 - `Microsoft.VisualStudioCode` is the unique identifier for VS Code in the winget catalog
+
+</details>
 
 </details>
 
@@ -46,10 +50,14 @@ winget install Microsoft.VisualStudioCode
 brew install --cask visual-studio-code
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `brew` is the Homebrew package manager for Mac
 - `install --cask` installs a graphical application (as opposed to a command-line tool)
 - `visual-studio-code` is the package name for VS Code
+
+</details>
 
 This requires [Homebrew](https://brew.sh/). If you don't have it, use the GUI method above.
 
@@ -63,11 +71,15 @@ This requires [Homebrew](https://brew.sh/). If you don't have it, use the GUI me
 sudo snap install code --classic
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `sudo` runs the command with administrator privileges (it will ask for your password)
 - `snap install` installs a program using the Snap package manager
 - `code` is the package name for VS Code
 - `--classic` allows VS Code full access to your system (needed for a code editor to work properly)
+
+</details>
 
 Or download the `.deb`/`.rpm` package from [code.visualstudio.com](https://code.visualstudio.com/) and install it with your package manager.
 
@@ -121,9 +133,13 @@ code --install-extension eamodio.gitlens
 code --install-extension esbenp.prettier-vscode
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `code` is the VS Code command-line tool
 - `--install-extension` tells it to install an extension by its unique identifier
+
+</details>
 
 > **Note:** You may install additional extensions later depending on your project (like the Python extension for Python projects). Claude Code will recommend them when the time comes.
 

--- a/wiki/04-Install-Git.md
+++ b/wiki/04-Install-Git.md
@@ -27,9 +27,13 @@ Imagine you're writing an essay and you save a new copy every time you make a bi
 winget install Git.Git
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `winget install` tells the Windows package manager to install a program
 - `Git.Git` is the unique identifier for Git in the winget catalog
+
+</details>
 
 </details>
 
@@ -41,8 +45,12 @@ Open Terminal and run:
 xcode-select --install
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `xcode-select --install` installs Apple's Command Line Tools, which includes Git
+
+</details>
 
 Follow the prompts. Alternatively, if you have [Homebrew](https://brew.sh/):
 ```bash
@@ -67,10 +75,14 @@ sudo dnf install git
 sudo pacman -S git
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `sudo` runs the command with administrator privileges
 - `apt update` refreshes the list of available packages
 - `apt install git` installs Git
+
+</details>
 
 </details>
 
@@ -110,11 +122,15 @@ Run these commands in your VS Code terminal, replacing the placeholder values wi
 git config --global user.name "Your Name"
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `git config` changes a Git setting
 - `--global` applies this setting to all repositories on your computer (not just one)
 - `user.name` is the setting name
 - `"Your Name"` is the value to set. **Replace this** with your actual name or GitHub username
+
+</details>
 
 ```bash
 git config --global user.email "123456789+yourusername@users.noreply.github.com"
@@ -139,10 +155,14 @@ Run this command in your VS Code terminal, replacing the email with your GitHub 
 ssh-keygen -t ed25519 -C "123456789+yourusername@users.noreply.github.com"
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `ssh-keygen` is the tool that creates SSH key pairs
 - `-t ed25519` specifies the type of key to create (Ed25519 is modern and secure)
 - `-C "..."` adds a comment (label) to the key so you can identify it later. **Replace** the email with your GitHub noreply email
+
+</details>
 
 The tool will walk you through a few prompts. Here's what to expect at each one:
 
@@ -191,9 +211,13 @@ Now you need to give GitHub your **public** key so it recognizes your computer.
    cat ~/.ssh/id_ed25519.pub
    ```
 
-   **What's happening here:**
+   <details open>
+   <summary><strong>What's happening here</strong></summary>
+
    - `cat` displays the contents of a file
    - `~/.ssh/id_ed25519.pub` is the path to your public key file
+
+   </details>
 
    You'll see one long line that looks like:
    ```
@@ -210,9 +234,13 @@ Now you need to give GitHub your **public** key so it recognizes your computer.
    pbcopy < ~/.ssh/id_ed25519.pub
    ```
 
-   **What's happening here:**
+   <details open>
+   <summary><strong>What's happening here</strong></summary>
+
    - `pbcopy` copies text to your clipboard
    - `< ~/.ssh/id_ed25519.pub` feeds the contents of the public key file into `pbcopy`
+
+   </details>
 
    This copies the key directly to your clipboard.
 
@@ -244,9 +272,13 @@ Back in your **VS Code terminal**, run:
 ssh -T git@github.com
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `ssh -T` tests the SSH connection without starting a full session
 - `git@github.com` is the address you're connecting to
+
+</details>
 
 If this is your first time connecting to GitHub via SSH, you'll see a warning like:
 ```

--- a/wiki/05-Install-Node.md
+++ b/wiki/05-Install-Node.md
@@ -25,10 +25,14 @@ Before installing fnm on Windows, you need to allow PowerShell to run scripts. B
    Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
    ```
 
-   **What's happening here:**
+   <details open>
+   <summary><strong>What's happening here</strong></summary>
+
    - `Set-ExecutionPolicy` changes which scripts PowerShell is allowed to run
    - `-Scope CurrentUser` applies this setting only to your user account, not the whole system
    - `-ExecutionPolicy RemoteSigned` allows scripts you write on your computer to run freely, while scripts downloaded from the internet must be signed by a trusted publisher
+
+   </details>
 
 3. If prompted to confirm, type `Y` and press Enter
 4. Close this admin terminal. You won't need admin privileges for the remaining steps.
@@ -48,9 +52,13 @@ Open a regular (non-admin) PowerShell or terminal and run:
 winget install Schniz.fnm
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `winget install` tells the Windows package manager to install a program
 - `Schniz.fnm` is the unique identifier for fnm in the winget catalog
+
+</details>
 
 Next, **set up your shell profile.** This step tells PowerShell to activate fnm every time you open a terminal:
 
@@ -59,9 +67,13 @@ if (!(Test-Path $PROFILE)) { New-Item -Path $PROFILE -Force }
 Add-Content -Path $PROFILE -Value 'fnm env --use-on-cd --shell powershell | Out-String | Invoke-Expression'
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - The first line creates your PowerShell profile file if it doesn't already exist
 - The second line adds a command to that profile file. Every time you open a new terminal, this command activates fnm so you can use Node.js
+
+</details>
 
 **What's a shell profile?** It's a script that runs automatically every time you open a new terminal window. Think of it like startup settings for your command line. The file lives at `$PROFILE`. You can type that in PowerShell to see the exact path.
 
@@ -88,11 +100,15 @@ Install fnm with the install script:
 curl -fsSL https://fnm.vercel.app/install | bash
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `curl` downloads content from a URL
 - `-fsSL` is a set of flags: fail silently on errors, show errors, follow redirects, and keep it clean
 - `https://fnm.vercel.app/install` is the URL of the fnm install script
 - `| bash` passes the downloaded script to Bash to run it
+
+</details>
 
 ### 🔒 Security Note
 
@@ -120,9 +136,13 @@ fnm install --lts
 fnm use lts-latest
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `fnm install --lts` downloads and installs the latest LTS version of Node.js
 - `fnm use lts-latest` tells fnm to activate that version so you can use it
+
+</details>
 
 You should see output like:
 ```

--- a/wiki/06-Install-Claude-Code.md
+++ b/wiki/06-Install-Claude-Code.md
@@ -14,10 +14,14 @@ Run this command:
 npm install -g @anthropic-ai/claude-code
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `npm install` tells npm (Node Package Manager) to install a package
 - `-g` means "globally," making it available everywhere on your computer, not just in one project folder
 - `@anthropic-ai/claude-code` is the name of the package to install. The `@anthropic-ai/` part is the organization that publishes it
+
+</details>
 
 This may take a minute. You'll see progress output ending with something like:
 ```

--- a/wiki/07-Clone-This-Repo.md
+++ b/wiki/07-Clone-This-Repo.md
@@ -34,9 +34,13 @@ Navigate to where you want to keep your projects. A common choice:
 cd ~/Documents
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `cd` means "change directory" (move to a different folder)
 - `~/Documents` is a shortcut to your Documents folder. The `~` symbol means "my home folder"
+
+</details>
 
 </details>
 
@@ -47,9 +51,13 @@ cd ~/Documents
 cd ~/projects
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `cd` means "change directory" (move to a different folder)
 - `~/projects` is a folder in your home directory
+
+</details>
 
 Create the folder first if it doesn't exist:
 ```bash
@@ -64,10 +72,14 @@ Now clone your repo. In the command below, **replace `YOUR_USERNAME`** with your
 git clone git@github.com:YOUR_USERNAME/first-build.git
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `git clone` downloads a repository from the internet to your computer
 - `git@github.com:YOUR_USERNAME/first-build.git` is the SSH address of your repo (this is why we set up SSH keys earlier)
 - **Important:** Replace `YOUR_USERNAME` with your actual GitHub username. For example, if your username is `janedoe`, the command would be `git clone git@github.com:janedoe/first-build.git`
+
+</details>
 
 > **You'll be asked for your SSH passphrase.** This is the passphrase you created when generating your SSH key on the [Install Git](04-Install-Git) page. Type it in (you won't see characters as you type) and press Enter.
 
@@ -88,8 +100,12 @@ Now move into the project folder:
 cd first-build
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `cd first-build` moves you into the newly downloaded project folder
+
+</details>
 
 ## Step 3: Open the Project in VS Code
 
@@ -99,9 +115,13 @@ Since you're already in VS Code, run this command to open the project folder:
 code .
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `code` launches VS Code
 - `.` means "the current directory" (the `first-build` folder you just moved into)
+
+</details>
 
 This will open a **new VS Code window** with the project files visible in the sidebar. You can close your old VS Code window.
 
@@ -120,9 +140,13 @@ In your **new VS Code window**, open the terminal if it isn't already open (`` C
 .\setup.ps1
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `.\` means "in the current directory"
 - `setup.ps1` is the PowerShell verification script
+
+</details>
 
 > **If you get a permission error:** You may need to allow script execution. Run this first:
 > ```powershell
@@ -139,9 +163,13 @@ In your **new VS Code window**, open the terminal if it isn't already open (`` C
 ./setup.sh
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `./` means "in the current directory"
 - `setup.sh` is the Bash verification script
+
+</details>
 
 </details>
 

--- a/wiki/09-Your-First-Session.md
+++ b/wiki/09-Your-First-Session.md
@@ -57,8 +57,12 @@ Type:
 claude
 ```
 
-**What's happening here:**
+<details open>
+<summary><strong>What's happening here</strong></summary>
+
 - `claude` launches Claude Code in the current directory
+
+</details>
 
 Claude Code will then ask you to authenticate with your Anthropic account. Follow the prompts. It will typically open a browser window where you log in.
 


### PR DESCRIPTION
## Summary
- Converted all 26 "What's happening here:" sections across 6 wiki pages to `<details open>` blocks
- Expanded by default so beginners see explanations without clicking
- Collapsible so learners can minimize them as they get comfortable
- Uses wiki-compatible HTML syntax

Closes #32

## Test plan
- [ ] Verify `<details open>` blocks render correctly on the wiki (expanded by default)
- [ ] Verify they can be collapsed by clicking the summary
- [ ] Check nested details blocks (inside platform-specific sections) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)