### PR TITLE
fix: correct SSH-key wiki page reference and refresh stale version examples

### DIFF
--- a/setup.ps1
+++ b/setup.ps1
@@ -78,7 +78,7 @@ if ($sshKeys) {
     Test-Check -Label "SSH key" -Success $true -Message "Found"
 }
 else {
-    Test-Check -Label "SSH key" -Success $false -Message "Not found. See wiki page '03-Install-Git' for setup instructions."
+    Test-Check -Label "SSH key" -Success $false -Message "Not found. See wiki page '04-Install-Git' for setup instructions."
 }
 
 # 5. Node.js installed (>= 18)

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ fi
 if ls ~/.ssh/id_* &>/dev/null; then
     check "SSH key" 0 "Found"
 else
-    check "SSH key" 1 "Not found. See wiki page '03-Install-Git' for setup instructions."
+    check "SSH key" 1 "Not found. See wiki page '04-Install-Git' for setup instructions."
 fi
 
 # 5. Node.js installed (>= 18)

--- a/wiki/05-Install-Node.md
+++ b/wiki/05-Install-Node.md
@@ -146,9 +146,9 @@ fnm use lts-latest
 
 You should see output like:
 ```
-Installing Node v20.11.0 (x64)
-Done installing Node v20.11.0 (x64)
-Using Node v20.11.0
+Installing Node v22.22.2 (x64)
+Done installing Node v22.22.2 (x64)
+Using Node v22.22.2
 ```
 
 These commands are the same on Windows, Mac, and Linux.
@@ -164,7 +164,7 @@ node --version
 ```
 You should see something like:
 ```
-v20.11.0
+v22.22.2
 ```
 As long as it's version 18 or above, you're good.
 
@@ -173,7 +173,7 @@ npm --version
 ```
 You should see something like:
 ```
-10.2.3
+10.9.7
 ```
 
 ## What's npm?

--- a/wiki/06-Install-Claude-Code.md
+++ b/wiki/06-Install-Claude-Code.md
@@ -36,7 +36,7 @@ claude --version
 
 You should see something like:
 ```
-1.0.12 (Claude Code)
+2.1.177 (Claude Code)
 ```
 
 If you get "command not found," close and reopen your terminal, then try again.

--- a/wiki/07-Clone-This-Repo.md
+++ b/wiki/07-Clone-This-Repo.md
@@ -184,9 +184,9 @@ The script will check for Git, Node.js, npm, Claude Code, and your SSH key, prin
 ✅ Git user.name - Jane Doe
 ✅ Git user.email - jane@example.com
 ✅ SSH key - Found
-✅ Node.js - v20.11.0
-✅ npm - 10.2.3
-✅ Claude Code - 1.0.12 (Claude Code)
+✅ Node.js - v22.22.2
+✅ npm - 10.9.7
+✅ Claude Code - 2.1.177 (Claude Code)
 ✅ Git repo - Detected
 
 -----------------------------------------

--- a/wiki/Appendix-Password-Management.md
+++ b/wiki/Appendix-Password-Management.md
@@ -26,7 +26,7 @@ Choose a **strong master password**. This is the one password you need to memori
 ### 2. Install the browser extension
 
 Install the Bitwarden extension for your browser:
-- **Chrome/Edge:** [Chrome Web Store](https://chrome.google.com/webstore/detail/bitwarden/nngceckbapebfimnlniiiahkandclblb)
+- **Chrome/Edge:** [Chrome Web Store](https://chromewebstore.google.com/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb)
 - **Firefox:** [Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/bitwarden-password-manager/)
 - **Safari:** Available in the Mac App Store
 


### PR DESCRIPTION
- setup.sh/setup.ps1: SSH key failure pointed to '03-Install-Git', but that
  page is now GitHub Basics after the wiki reorder. Install Git is page 04.
- Bump sample Node/npm/Claude Code version output to match current releases
  (Claude Code 1.x -> 2.x is the most visible jump).
- Update Bitwarden Chrome Web Store link to the current chromewebstore.google.com
  domain.